### PR TITLE
private/public controls are logically "or"

### DIFF
--- a/src/plugin/modules/components/controls/accessControl.js
+++ b/src/plugin/modules/components/controls/accessControl.js
@@ -89,7 +89,8 @@ define([
                 input({
                     type: 'checkbox',
                     dataBind: {
-                        checked: 'withPrivateData'
+                        checked: 'withPrivateData',
+                        enable: 'withPublicData'
                     }
                 }),
                 ' Private'
@@ -106,7 +107,8 @@ define([
                 input({
                     type: 'checkbox',
                     dataBind: {
-                        checked: 'withPublicData'
+                        checked: 'withPublicData',
+                        enable: 'withPrivateData'
                     }
                 }),
                 ' Public'


### PR DESCRIPTION
- a recent searchapi now throws an error if both with_public and with_private are false.
- this change prevents the ui from setting these values both to false